### PR TITLE
BAU: Add support for RSA-2048 public JWKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for doing things with KMS and public keys.
 
 It can 
  - create CSRs and self-signed certificates signed by a private key stored in AWS KMS.
- - create public key JWKs for P-256 EC keys
+ - create public key JWKs for P-256 EC keys and RSA-2048 keys
 
 ## Requirements
 
@@ -55,9 +55,9 @@ options run:
 java -jar jar/di-ipv-kms-public-key-operations-all.jar csr
 ```
 
-### Public key JWKs for EC keys
+### Public key JWKs
 
-This will only work for KMS keys using the NIST P-256 elliptic curve.
+This will only work for KMS keys using the NIST P-256 elliptic curve, or RSA-2048 keys.
 
 The only option for this command is the `keyAlias`. You can create a JWK with:
 

--- a/src/main/java/uk/gov/di/ipv/kmspublickeyops/JwkCommand.java
+++ b/src/main/java/uk/gov/di/ipv/kmspublickeyops/JwkCommand.java
@@ -2,16 +2,18 @@ package uk.gov.di.ipv.kmspublickeyops;
 
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.jce.provider.ec.KmsECKeyFactory;
-import software.amazon.awssdk.services.kms.jce.provider.ec.KmsECPublicKey;
+import software.amazon.awssdk.services.kms.jce.provider.rsa.KmsRSAKeyFactory;
 import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
 import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
+import software.amazon.awssdk.services.kms.model.KeySpec;
 
-@Command(name = "jwk", description = "Generates a JWK for a KMS EC P-256 public key")
-public class JwkCommand implements Runnable{
+@Command(name = "jwk", description = "Generates a JWK for a KMS EC P-256 or RSA-2048 public key")
+public class JwkCommand implements Runnable {
 
     @Option(names = "--keyAlias", required = true, description = "Required: The KMS key alias for the key to generate a JWK for (including the 'alias/' prefix)")
     private String keyAlias;
@@ -23,13 +25,27 @@ public class JwkCommand implements Runnable{
         DescribeKeyResponse describeKeyResponse = client.describeKey(
                 DescribeKeyRequest.builder().keyId(keyAlias).build()
         );
-        KmsECPublicKey publicKey = KmsECKeyFactory.getPublicKey(
-                client,
-                describeKeyResponse.keyMetadata().keyId()
-        );
 
-        System.out.println(
-                new ECKey.Builder(Curve.P_256, publicKey).build().toPublicJWK().toJSONString()
-        );
+        String publicJwk;
+        KeySpec keySpec = describeKeyResponse.keyMetadata().keySpec();
+
+        switch (keySpec) {
+            case ECC_NIST_P256:
+                publicJwk = new ECKey.Builder(Curve.P_256, KmsECKeyFactory.getPublicKey(
+                        client,
+                        describeKeyResponse.keyMetadata().keyId()
+                )).build().toPublicJWK().toJSONString();
+                break;
+            case RSA_2048:
+                publicJwk = new RSAKey.Builder(KmsRSAKeyFactory.getPublicKey(
+                        client,
+                        describeKeyResponse.keyMetadata().keyId()
+                )).build().toPublicJWK().toJSONString();
+                break;
+            default:
+                throw new RuntimeException(String.format("Unsupported KeySpec: %s", keySpec));
+        }
+
+        System.out.println(publicJwk);
     }
 }


### PR DESCRIPTION
We now have a need to provide a public JWK for an RSA-2048 public key.
This is for the encryption key used by core to decrypt messages from the
core's client's JARs (orchestrator)