### PR TITLE
BAU: Add use attribute to our public jwks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ java -jar jar/di-ipv-kms-public-key-operations-all.jar csr
 
 This will only work for KMS keys using the NIST P-256 elliptic curve, or RSA-2048 keys.
 
-The only option for this command is the `keyAlias`. You can create a JWK with:
+The 2 options for this command is the `keyAlias` and `keyUse`. You can create a JWK with:
 
 ```bash
-java -jar jar/di-ipv-kms-public-key-operations-all.jar jwk --keyAlias 'alias/myKeyAlias'
+java -jar jar/di-ipv-kms-public-key-operations-all.jar jwk --keyAlias 'alias/myKeyAlias' --keyUse 'sig'
 ```
 
 ## Building the jar yourself.
@@ -78,3 +78,5 @@ Once you've done that just run:
 ```bash
 ./gradlew shadowJar
 ```
+
+The build jar will be inside the build/libs folder. Just copy the jar ending in "-all" over to the jar folder.

--- a/src/main/java/uk/gov/di/ipv/kmspublickeyops/JwkCommand.java
+++ b/src/main/java/uk/gov/di/ipv/kmspublickeyops/JwkCommand.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.kmspublickeyops;
 
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -12,11 +13,16 @@ import software.amazon.awssdk.services.kms.model.DescribeKeyRequest;
 import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
 import software.amazon.awssdk.services.kms.model.KeySpec;
 
+import java.text.ParseException;
+
 @Command(name = "jwk", description = "Generates a JWK for a KMS EC P-256 or RSA-2048 public key")
 public class JwkCommand implements Runnable {
 
     @Option(names = "--keyAlias", required = true, description = "Required: The KMS key alias for the key to generate a JWK for (including the 'alias/' prefix)")
     private String keyAlias;
+
+    @Option(names = "--keyUse", required = true, description = "Required: The intended use for the key")
+    private String keyUse;
 
     @Override
     public void run() {
@@ -29,21 +35,26 @@ public class JwkCommand implements Runnable {
         String publicJwk;
         KeySpec keySpec = describeKeyResponse.keyMetadata().keySpec();
 
+        try {
         switch (keySpec) {
             case ECC_NIST_P256:
                 publicJwk = new ECKey.Builder(Curve.P_256, KmsECKeyFactory.getPublicKey(
                         client,
                         describeKeyResponse.keyMetadata().keyId()
-                )).build().toPublicJWK().toJSONString();
+                )).keyUse(KeyUse.parse(keyUse)).build().toPublicJWK().toJSONString();
                 break;
             case RSA_2048:
                 publicJwk = new RSAKey.Builder(KmsRSAKeyFactory.getPublicKey(
                         client,
                         describeKeyResponse.keyMetadata().keyId()
-                )).build().toPublicJWK().toJSONString();
+                )).keyUse(KeyUse.parse(keyUse)).build().toPublicJWK().toJSONString();
                 break;
             default:
                 throw new RuntimeException(String.format("Unsupported KeySpec: %s", keySpec));
+        }
+
+        } catch (ParseException e) {
+            throw new RuntimeException(String.format("Unsupported key use: %s", keyUse));
         }
 
         System.out.println(publicJwk);


### PR DESCRIPTION
Add new keyUse flag to the kms-scr-generator so that the `use` attribute is added onto our public jwk's.

Also updated README with how to use the new flag.