### PR TITLE
BAU: Extend jwe decrypt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ java -jar jar/di-ipv-kms-public-key-operations-all.jar jwk --keyAlias 'alias/myK
 
 ### Decrypting JWEs
 
-This is useful for looking at the payload of JAR requests coming from orchestrator to core. You'll need the key ID for 
-the KMS key used to decrypt - this can be lifted straight from the core's config for the env you're using. And the
-serialized version of the JAR.
+This is useful for looking at the payload of JAR requests. You'll need either a KMS key ID, or the private key in JWK
+format.
+
+The KMS key ID for core can be lifted straight from [core's config for the env you're using](https://github.com/govuk-one-login/ipv-core-common-infra/blob/main/utils/config-mgmt/app/configs/core.staging.params.yaml#L129). 
+You can find private keys for the stubs in the [stubs config](https://github.com/govuk-one-login/ipv-stubs-common-infra/blob/main/utils/config-mgmt/app/configs/stubs.production.params.yaml#L346).
 
 It will output the serialized signed JWT, and the pretty printed jwt payload to std out.
 
 ```bash
-java -jar jar/di-ipv-kms-public-key-operations-all.jar jwe-decrypt --jwe "A.STRING.SEPARATED.WITH.PERIODS" --keyId "12345678-90ab-cdef-1234567890ab"
+java -jar jar/di-ipv-kms-public-key-operations-all.jar jwe-decrypt --jwe=<jwe> [--kms-key-id=<kmsKeyId> | --private-key-jwk=<privateKeyJwk>]
 ```
 
 ## Building the jar yourself.

--- a/src/main/java/uk/gov/di/ipv/kmspublickeyops/JweDecryptCommand.java
+++ b/src/main/java/uk/gov/di/ipv/kmspublickeyops/JweDecryptCommand.java
@@ -8,6 +8,7 @@ import com.nimbusds.jose.JWEDecrypter;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.SignedJWT;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -64,15 +65,31 @@ public class JweDecryptCommand implements Runnable {
             throw new RuntimeException("Unable to decrypt JWE", e);
         }
 
-        System.out.println("Payload:");
+        System.out.println();
+
+        System.out.println("JWE header:");
+        System.out.println(jarObject.getHeader().toString());
+        System.out.println();
+
+        System.out.println("JWE payload:");
         System.out.println(jarObject.getPayload().toString());
+        System.out.println();
 
         System.out.println();
 
-        System.out.println("JWT:");
+        SignedJWT signedJWT = jarObject.getPayload().toSignedJWT();
+
+        System.out.println("JWT header:");
+        System.out.println(
+                GSON.toJson(JsonParser.parseString(
+                        signedJWT.getHeader().toString()))
+        );
+        System.out.println();
+
+        System.out.println("JWT payload:");
         System.out.println(
                 GSON.toJson(
                     JsonParser.parseString(
-                            jarObject.getPayload().toSignedJWT().getPayload().toString())));
+                            signedJWT.getPayload().toString())));
     }
 }

--- a/src/main/java/uk/gov/di/ipv/kmspublickeyops/JweDecryptCommand.java
+++ b/src/main/java/uk/gov/di/ipv/kmspublickeyops/JweDecryptCommand.java
@@ -4,7 +4,11 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEDecrypter;
 import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jose.jwk.RSAKey;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import uk.gov.di.ipv.service.KmsRsaDecrypter;
@@ -16,15 +20,36 @@ public class JweDecryptCommand implements Runnable {
 
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
+    @ArgGroup
+    KeySource keySource;
+
+    static class KeySource {
+        @Option(names = "--kms-key-id", description = "The ID of the KMS key to decrypt with")
+        private String kmsKeyId;
+
+        @Option(names = "--private-key-jwk", description = "The private key JWK to decrypt with")
+        private String privateKeyJwk;
+    }
+
     @Option(names = "--jwe", required = true, description = "Required: The jwe to decrypt")
     private String jwe;
 
-    @Option(names = "--keyId", required = true, description = "Required: the ID of the KMS key to decrypt with")
-    private String keyId;
+
 
     @Override
     public void run() {
-        KmsRsaDecrypter kmsRsaDecrypter = new KmsRsaDecrypter(keyId);
+
+        JWEDecrypter decrypter;
+        if (keySource.privateKeyJwk != null) {
+            try {
+                decrypter = new RSADecrypter(
+                        RSAKey.parse(keySource.privateKeyJwk));
+            } catch (JOSEException | ParseException e) {
+                throw new RuntimeException("Unable to parse privateKeyJwk");
+            }
+        } else {
+            decrypter = new KmsRsaDecrypter(keySource.kmsKeyId);
+        }
 
         JWEObject jarObject;
         try {
@@ -34,7 +59,7 @@ public class JweDecryptCommand implements Runnable {
         }
 
         try {
-            jarObject.decrypt(kmsRsaDecrypter);
+            jarObject.decrypt(decrypter);
         } catch (JOSEException e) {
             throw new RuntimeException("Unable to decrypt JWE", e);
         }


### PR DESCRIPTION
[BAU: Allow decrypt with non KMS keys](https://github.com/govuk-one-login/di-ipv-kms-csr-generator/commit/3c92bf9c15ded338630e8e1da1816bf3fabe7505)

JARs for the CRI stubs are not encrypted using a KMS key. This allows
the private key used to be passed in in JWK format, rather than using a
KMS key ID.

[BAU: Output more JAR detail](https://github.com/govuk-one-login/di-ipv-kms-csr-generator/commit/70952fc53bd2ef629741edd80c38eee0d062608f)

This updates the decrypt command to out put the header of the encrypted
object, as well as the header of the signed JWT payload. Useful for
inspecting kids.